### PR TITLE
Traductor de milisegundos a fechas y viceversa

### DIFF
--- a/src/server/webapps/.shared/src/app/app.module.ts
+++ b/src/server/webapps/.shared/src/app/app.module.ts
@@ -5,15 +5,15 @@ import { BrowserModule } from '@angular/platform-browser';
 import { HttpModule } from '@angular/http';
 import { LocationStrategy, HashLocationStrategy } from '@angular/common';
 import { UIRouterModule } from 'ui-router-ng2';
-import { DashboardComponent } from './shared/components/Dashboard';
-import { DashboardService } from './shared/services/Dashboard';
-import { ResourcesService } from './shared/services/Resources';
+import { sharedServicesList } from "./shared/services/index";
+import { sharedComponentList } from './shared/components/index';
+import { DateService } from './shared/services/Date';
 import { AppComponent } from './app';
 import { statesConfig } from './app.routes';
 
 
 @NgModule({
-  declarations: [ AppComponent, DashboardComponent ],
+  declarations: [ AppComponent ].concat(sharedComponentList),
   imports: [
     BrowserModule,
     FormsModule,
@@ -21,7 +21,7 @@ import { statesConfig } from './app.routes';
     HttpModule,
     UIRouterModule.forRoot(statesConfig)
   ],
-  providers: [ DashboardService, ResourcesService ],
+  providers: [ ].concat(sharedServicesList),
   bootstrap: [ AppComponent ]
 })
 export class AppModule {}

--- a/src/server/webapps/.shared/src/app/app.pug
+++ b/src/server/webapps/.shared/src/app/app.pug
@@ -1,1 +1,12 @@
 dashboard
+
+div
+    input(
+        type="date",
+        [(ngModel)]="dateToConvert",
+        (change)="convert()"
+    )
+    br
+    span {{convertedDate}}
+    br
+    span {{convertedDate1}}

--- a/src/server/webapps/.shared/src/app/app.ts
+++ b/src/server/webapps/.shared/src/app/app.ts
@@ -1,6 +1,7 @@
 import {Component, OnInit} from '@angular/core';
 import {DashboardService} from "./shared/services/Dashboard";
 import {ResourcesService} from "./shared/services/Resources";
+import {DateService} from "./shared/services/Date"; 
 
 @Component({
   selector: 'app',
@@ -10,24 +11,22 @@ export class AppComponent implements OnInit{
 
   dashboard: DashboardService;
   resources: ResourcesService;
+  date: DateService;
+  dateToConvert: Date;
+  convertedDate: number;
+  convertedDate1: string;
 
-  constructor(dashboard: DashboardService, resources: ResourcesService){
+  constructor(dashboard: DashboardService, resources: ResourcesService, date: DateService){
     this.dashboard = dashboard;
     this.resources = resources;
+    this.date = date;
+    this.dateToConvert = null;
+    this.convertedDate = null;
+    this.convertedDate1 = "";
   }
 
   ngOnInit () {
-    this.resources.getOrdersByOutput(false).subscribe(
-      (data) => {
-        console.log("Get orders by output");
-        console.log(data);
-      },
-      (err) => {
-        console.log("Get orders by output");
-        console.log(err);
-      }
 
-    );
     this.dashboard.registerModule({
       name: "Test Module1",
       submodules: [
@@ -63,5 +62,10 @@ export class AppComponent implements OnInit{
         }
       ]
     });
+  }
+
+  convert() {
+    this.convertedDate = this.date.convertDate(this.dateToConvert);
+    this.convertedDate1 = this.date.convertDate(this.convertedDate);
   }
 }

--- a/src/server/webapps/.shared/src/app/shared/services/Date.ts
+++ b/src/server/webapps/.shared/src/app/shared/services/Date.ts
@@ -4,11 +4,9 @@ import {Injectable} from '@angular/core';
 export class DateService {
 
   // Attributes
-    now: number;
     
   // Methods
   constructor () {
-    this.now = 0;
   }
 
   convertDate(date: any): any {

--- a/src/server/webapps/.shared/src/app/shared/services/Date.ts
+++ b/src/server/webapps/.shared/src/app/shared/services/Date.ts
@@ -1,0 +1,29 @@
+import {Injectable} from '@angular/core';
+
+@Injectable()
+export class DateService {
+
+  // Attributes
+    now: number;
+    
+  // Methods
+  constructor () {
+    this.now = 0;
+  }
+
+  convertDate(date: any): any {
+      if(typeof(date) == 'number') {
+          console.log(123);
+        let newDate: Date = new Date(date);
+        return newDate.getDate() + '-' + (newDate.getMonth() + 1) + '-' + newDate.getFullYear();
+      }
+      else{
+        date = date.split('-');
+        date = date[1] + '/' + date[2] + '/' + date[0];
+        let newDate: Date = new Date(date);
+        return newDate.getTime();
+      }
+      
+  }
+  
+}

--- a/src/server/webapps/.shared/src/app/shared/services/index.ts
+++ b/src/server/webapps/.shared/src/app/shared/services/index.ts
@@ -1,9 +1,11 @@
 import { DashboardService } from './Dashboard';
-import { ResourcesService } from './Resources'
+import { ResourcesService } from './Resources';
+import { DateService } from "./Date";
 
 export let sharedServices = {
   ResourcesService: ResourcesService,
-  DashboardService: DashboardService
+  DashboardService: DashboardService,
+  DateService: DateService
 };
 
 export let sharedServicesList = Object.keys(sharedServices).map((key) => {

--- a/src/server/webapps/access/src/app/shared/services/Date.ts
+++ b/src/server/webapps/access/src/app/shared/services/Date.ts
@@ -4,11 +4,9 @@ import {Injectable} from '@angular/core';
 export class DateService {
 
   // Attributes
-    now: number;
     
   // Methods
   constructor () {
-    this.now = 0;
   }
 
   convertDate(date: any): any {

--- a/src/server/webapps/access/src/app/shared/services/Date.ts
+++ b/src/server/webapps/access/src/app/shared/services/Date.ts
@@ -1,0 +1,29 @@
+import {Injectable} from '@angular/core';
+
+@Injectable()
+export class DateService {
+
+  // Attributes
+    now: number;
+    
+  // Methods
+  constructor () {
+    this.now = 0;
+  }
+
+  convertDate(date: any): any {
+      if(typeof(date) == 'number') {
+          console.log(123);
+        let newDate: Date = new Date(date);
+        return newDate.getDate() + '-' + (newDate.getMonth() + 1) + '-' + newDate.getFullYear();
+      }
+      else{
+        date = date.split('-');
+        date = date[1] + '/' + date[2] + '/' + date[0];
+        let newDate: Date = new Date(date);
+        return newDate.getTime();
+      }
+      
+  }
+  
+}

--- a/src/server/webapps/access/src/app/shared/services/index.ts
+++ b/src/server/webapps/access/src/app/shared/services/index.ts
@@ -1,9 +1,11 @@
 import { DashboardService } from './Dashboard';
-import { ResourcesService } from './Resources'
+import { ResourcesService } from './Resources';
+import { DateService } from "./Date";
 
 export let sharedServices = {
   ResourcesService: ResourcesService,
-  DashboardService: DashboardService
+  DashboardService: DashboardService,
+  DateService: DateService
 };
 
 export let sharedServicesList = Object.keys(sharedServices).map((key) => {

--- a/src/server/webapps/confirm-order/src/app/shared/services/Date.ts
+++ b/src/server/webapps/confirm-order/src/app/shared/services/Date.ts
@@ -4,11 +4,9 @@ import {Injectable} from '@angular/core';
 export class DateService {
 
   // Attributes
-    now: number;
     
   // Methods
   constructor () {
-    this.now = 0;
   }
 
   convertDate(date: any): any {

--- a/src/server/webapps/confirm-order/src/app/shared/services/Date.ts
+++ b/src/server/webapps/confirm-order/src/app/shared/services/Date.ts
@@ -1,0 +1,29 @@
+import {Injectable} from '@angular/core';
+
+@Injectable()
+export class DateService {
+
+  // Attributes
+    now: number;
+    
+  // Methods
+  constructor () {
+    this.now = 0;
+  }
+
+  convertDate(date: any): any {
+      if(typeof(date) == 'number') {
+          console.log(123);
+        let newDate: Date = new Date(date);
+        return newDate.getDate() + '-' + (newDate.getMonth() + 1) + '-' + newDate.getFullYear();
+      }
+      else{
+        date = date.split('-');
+        date = date[1] + '/' + date[2] + '/' + date[0];
+        let newDate: Date = new Date(date);
+        return newDate.getTime();
+      }
+      
+  }
+  
+}

--- a/src/server/webapps/confirm-order/src/app/shared/services/index.ts
+++ b/src/server/webapps/confirm-order/src/app/shared/services/index.ts
@@ -1,9 +1,11 @@
 import { DashboardService } from './Dashboard';
-import { ResourcesService } from './Resources'
+import { ResourcesService } from './Resources';
+import { DateService } from "./Date";
 
 export let sharedServices = {
   ResourcesService: ResourcesService,
-  DashboardService: DashboardService
+  DashboardService: DashboardService,
+  DateService: DateService
 };
 
 export let sharedServicesList = Object.keys(sharedServices).map((key) => {

--- a/src/server/webapps/home/src/app/shared/services/Date.ts
+++ b/src/server/webapps/home/src/app/shared/services/Date.ts
@@ -4,11 +4,9 @@ import {Injectable} from '@angular/core';
 export class DateService {
 
   // Attributes
-    now: number;
     
   // Methods
   constructor () {
-    this.now = 0;
   }
 
   convertDate(date: any): any {

--- a/src/server/webapps/home/src/app/shared/services/Date.ts
+++ b/src/server/webapps/home/src/app/shared/services/Date.ts
@@ -1,0 +1,29 @@
+import {Injectable} from '@angular/core';
+
+@Injectable()
+export class DateService {
+
+  // Attributes
+    now: number;
+    
+  // Methods
+  constructor () {
+    this.now = 0;
+  }
+
+  convertDate(date: any): any {
+      if(typeof(date) == 'number') {
+          console.log(123);
+        let newDate: Date = new Date(date);
+        return newDate.getDate() + '-' + (newDate.getMonth() + 1) + '-' + newDate.getFullYear();
+      }
+      else{
+        date = date.split('-');
+        date = date[1] + '/' + date[2] + '/' + date[0];
+        let newDate: Date = new Date(date);
+        return newDate.getTime();
+      }
+      
+  }
+  
+}

--- a/src/server/webapps/home/src/app/shared/services/index.ts
+++ b/src/server/webapps/home/src/app/shared/services/index.ts
@@ -1,9 +1,11 @@
 import { DashboardService } from './Dashboard';
-import { ResourcesService } from './Resources'
+import { ResourcesService } from './Resources';
+import { DateService } from "./Date";
 
 export let sharedServices = {
   ResourcesService: ResourcesService,
-  DashboardService: DashboardService
+  DashboardService: DashboardService,
+  DateService: DateService
 };
 
 export let sharedServicesList = Object.keys(sharedServices).map((key) => {

--- a/src/server/webapps/register-order/src/app/components/Demo/index.ts
+++ b/src/server/webapps/register-order/src/app/components/Demo/index.ts
@@ -1,5 +1,6 @@
 import {Component, OnInit} from '@angular/core';
 import { ResourcesService } from "../../shared/services/Resources";
+import { DateService } from "../../shared/services/Date";
 import { FormGroup,FormArray,FormBuilder,Validators } from '@angular/forms';
 import * as dbModels from "../../../../../../../core/db-models/models";
 
@@ -12,15 +13,18 @@ export class DemoComponent implements OnInit {
 
     // Attributes
       resources: ResourcesService;
+      date: DateService;
       products: dbModels.Product[];
       detailList: dbModels.Detail[];
       bill: dbModels.Bill;
       order: dbModels.Order;
       guide: dbModels.RemissionGuide;
+      temporalDate: Date;
 
     // Methods
-      constructor (resources: ResourcesService) {
+      constructor (resources: ResourcesService, date: DateService) {
         this.resources = resources;
+        this.date = date;
         this.bill = {
           iva: 19,
           subtotal: 0,
@@ -78,6 +82,10 @@ export class DemoComponent implements OnInit {
 
         this.bill.total = this.bill.subtotal + this.bill.subtotal*(this.bill.iva/100);
 
+      }
+
+      setDate() {
+        this.order.arrivalDate = this.date.convertDate(this.temporalDate);
       }
 
       addProduct () {

--- a/src/server/webapps/register-order/src/app/components/Demo/index.ts
+++ b/src/server/webapps/register-order/src/app/components/Demo/index.ts
@@ -19,12 +19,17 @@ export class DemoComponent implements OnInit {
       bill: dbModels.Bill;
       order: dbModels.Order;
       guide: dbModels.RemissionGuide;
-      temporalDate: Date;
+      temporalDate1: Date;
+      temporalDate2: Date;
+      temporalDate3: Date;
 
     // Methods
       constructor (resources: ResourcesService, date: DateService) {
         this.resources = resources;
         this.date = date;
+        this.temporalDate1 = null;
+        this.temporalDate2 = null;
+        this.temporalDate3 = null;
         this.bill = {
           iva: 19,
           subtotal: 0,
@@ -84,8 +89,16 @@ export class DemoComponent implements OnInit {
 
       }
 
-      setDate() {
-        this.order.arrivalDate = this.date.convertDate(this.temporalDate);
+      setDate1() {
+        this.order.arrivalDate = this.date.convertDate(this.temporalDate1);
+      }
+
+      setDate2() {
+        this.guide.departureDate = this.date.convertDate(this.temporalDate2);
+      }
+
+      setDate3() {
+        this.guide.arrivalDate = this.date.convertDate(this.temporalDate3);
       }
 
       addProduct () {

--- a/src/server/webapps/register-order/src/app/components/Demo/template.pug
+++ b/src/server/webapps/register-order/src/app/components/Demo/template.pug
@@ -42,9 +42,10 @@ body
                 h3.pageSubtitle Arrival Date:
               td
                 input(
-                    type='number',
-                    [(ngModel)]='order.arrivalDate',
-                      required
+                    type='date',
+                    [(ngModel)]='temporalDate',
+                    (change)='setDate()',
+                    required
                   )
             tr
               td

--- a/src/server/webapps/register-order/src/app/components/Demo/template.pug
+++ b/src/server/webapps/register-order/src/app/components/Demo/template.pug
@@ -100,8 +100,9 @@ body
                   h3.pageSubtitle Departure:
                 td
                   input(
-                    type='number',
-                    [(ngModel)]='guide.departureDate',
+                    type='date',
+                    [(ngModel)]='temporalDate2',
+                    (change)="setDate2()",
                     required
                   )
               tr
@@ -109,8 +110,9 @@ body
                   h3.pageSubtitle Arrival:
                 td
                   input(
-                    type='number',
-                    [(ngModel)]='guide.arrivalDate',
+                    type='date',
+                    [(ngModel)]='temporalDate3',
+                    (change)="setDate3()",
                     required
                   )
               tr

--- a/src/server/webapps/register-order/src/app/shared/services/Date.ts
+++ b/src/server/webapps/register-order/src/app/shared/services/Date.ts
@@ -4,11 +4,9 @@ import {Injectable} from '@angular/core';
 export class DateService {
 
   // Attributes
-    now: number;
     
   // Methods
   constructor () {
-    this.now = 0;
   }
 
   convertDate(date: any): any {

--- a/src/server/webapps/register-order/src/app/shared/services/Date.ts
+++ b/src/server/webapps/register-order/src/app/shared/services/Date.ts
@@ -1,0 +1,29 @@
+import {Injectable} from '@angular/core';
+
+@Injectable()
+export class DateService {
+
+  // Attributes
+    now: number;
+    
+  // Methods
+  constructor () {
+    this.now = 0;
+  }
+
+  convertDate(date: any): any {
+      if(typeof(date) == 'number') {
+          console.log(123);
+        let newDate: Date = new Date(date);
+        return newDate.getDate() + '-' + (newDate.getMonth() + 1) + '-' + newDate.getFullYear();
+      }
+      else{
+        date = date.split('-');
+        date = date[1] + '/' + date[2] + '/' + date[0];
+        let newDate: Date = new Date(date);
+        return newDate.getTime();
+      }
+      
+  }
+  
+}

--- a/src/server/webapps/register-order/src/app/shared/services/index.ts
+++ b/src/server/webapps/register-order/src/app/shared/services/index.ts
@@ -1,9 +1,11 @@
 import { DashboardService } from './Dashboard';
-import { ResourcesService } from './Resources'
+import { ResourcesService } from './Resources';
+import { DateService } from "./Date";
 
 export let sharedServices = {
   ResourcesService: ResourcesService,
-  DashboardService: DashboardService
+  DashboardService: DashboardService,
+  DateService: DateService
 };
 
 export let sharedServicesList = Object.keys(sharedServices).map((key) => {

--- a/src/server/webapps/register-output-order/src/app/components/RegisterOutput/index.ts
+++ b/src/server/webapps/register-output-order/src/app/components/RegisterOutput/index.ts
@@ -1,6 +1,7 @@
 import {Component, OnInit} from '@angular/core';
 import {StateService} from 'ui-router-ng2';
 import { ResourcesService } from "../../shared/services/Resources";
+import { DateService } from "../../shared/services/Date";
 import * as dbModels from "../../../../../../../core/db-models/models";
 
 
@@ -12,6 +13,7 @@ export class RegisterOutputOrderComponent implements OnInit {
 
     // Attributes
       resources: ResourcesService;
+      date: DateService;
       state: StateService;
       products: dbModels.Product[];
       lots: dbModels.Lot[][];
@@ -20,12 +22,18 @@ export class RegisterOutputOrderComponent implements OnInit {
       bill: dbModels.Bill;
       order: dbModels.Order;
       guide: dbModels.RemissionGuide;
-
+      temporalDate1: Date;
+      temporalDate2: Date;
+      temporalDate3: Date;
 
     // Methods
-      constructor (resources: ResourcesService, state: StateService) {
+      constructor (resources: ResourcesService, state: StateService, date: DateService) {
         this.resources = resources;
         this.state = state;
+        this.date = date;
+        this.temporalDate1 = null;
+        this.temporalDate2 = null;
+        this.temporalDate3 = null;
         this.bill = {
           iva: 19,
           subtotal: 0,
@@ -64,6 +72,18 @@ export class RegisterOutputOrderComponent implements OnInit {
             console.log(err);
           }
         )
+      }
+
+      setDate1() {
+        this.order.arrivalDate = this.date.convertDate(this.temporalDate1);
+      }
+
+      setDate2() {
+        this.guide.departureDate = this.date.convertDate(this.temporalDate2);
+      }
+
+      setDate3() {
+        this.guide.arrivalDate = this.date.convertDate(this.temporalDate3);
       }
 
       verifyLots(index) {

--- a/src/server/webapps/register-output-order/src/app/components/RegisterOutput/template.pug
+++ b/src/server/webapps/register-output-order/src/app/components/RegisterOutput/template.pug
@@ -42,8 +42,9 @@ body
             h5.pageSubtitle Arrival Date:
           td
             input(
-              type='number',
-              [(ngModel)]='order.arrivalDate',
+              type='date',
+              [(ngModel)]='temporalDate1',
+              (change)="setDate1()",
               required
             )
         tr
@@ -120,8 +121,9 @@ body
             h5.pageSubtitle Departure:
           td
             input(
-              type='number',
-              [(ngModel)]='guide.departureDate',
+              type='date',
+              [(ngModel)]='temporalDate2',
+              (change)="setDate2()",
               required
             )
         tr
@@ -129,8 +131,9 @@ body
             h5.pageSubtitle Arrival:
           td
             input(
-              type='number',
-              [(ngModel)]='guide.arrivalDate',
+              type='date',
+              [(ngModel)]='temporalDate3',
+              (change)="setDate3()",
               required
             )
         tr

--- a/src/server/webapps/register-output-order/src/app/shared/services/Date.ts
+++ b/src/server/webapps/register-output-order/src/app/shared/services/Date.ts
@@ -4,11 +4,9 @@ import {Injectable} from '@angular/core';
 export class DateService {
 
   // Attributes
-    now: number;
     
   // Methods
   constructor () {
-    this.now = 0;
   }
 
   convertDate(date: any): any {

--- a/src/server/webapps/register-output-order/src/app/shared/services/Date.ts
+++ b/src/server/webapps/register-output-order/src/app/shared/services/Date.ts
@@ -1,0 +1,29 @@
+import {Injectable} from '@angular/core';
+
+@Injectable()
+export class DateService {
+
+  // Attributes
+    now: number;
+    
+  // Methods
+  constructor () {
+    this.now = 0;
+  }
+
+  convertDate(date: any): any {
+      if(typeof(date) == 'number') {
+          console.log(123);
+        let newDate: Date = new Date(date);
+        return newDate.getDate() + '-' + (newDate.getMonth() + 1) + '-' + newDate.getFullYear();
+      }
+      else{
+        date = date.split('-');
+        date = date[1] + '/' + date[2] + '/' + date[0];
+        let newDate: Date = new Date(date);
+        return newDate.getTime();
+      }
+      
+  }
+  
+}

--- a/src/server/webapps/register-output-order/src/app/shared/services/index.ts
+++ b/src/server/webapps/register-output-order/src/app/shared/services/index.ts
@@ -1,9 +1,11 @@
 import { DashboardService } from './Dashboard';
-import { ResourcesService } from './Resources'
+import { ResourcesService } from './Resources';
+import { DateService } from "./Date";
 
 export let sharedServices = {
   ResourcesService: ResourcesService,
-  DashboardService: DashboardService
+  DashboardService: DashboardService,
+  DateService: DateService
 };
 
 export let sharedServicesList = Object.keys(sharedServices).map((key) => {

--- a/src/server/webapps/register-product/src/app/shared/services/Date.ts
+++ b/src/server/webapps/register-product/src/app/shared/services/Date.ts
@@ -4,11 +4,9 @@ import {Injectable} from '@angular/core';
 export class DateService {
 
   // Attributes
-    now: number;
     
   // Methods
   constructor () {
-    this.now = 0;
   }
 
   convertDate(date: any): any {

--- a/src/server/webapps/register-product/src/app/shared/services/Date.ts
+++ b/src/server/webapps/register-product/src/app/shared/services/Date.ts
@@ -1,0 +1,29 @@
+import {Injectable} from '@angular/core';
+
+@Injectable()
+export class DateService {
+
+  // Attributes
+    now: number;
+    
+  // Methods
+  constructor () {
+    this.now = 0;
+  }
+
+  convertDate(date: any): any {
+      if(typeof(date) == 'number') {
+          console.log(123);
+        let newDate: Date = new Date(date);
+        return newDate.getDate() + '-' + (newDate.getMonth() + 1) + '-' + newDate.getFullYear();
+      }
+      else{
+        date = date.split('-');
+        date = date[1] + '/' + date[2] + '/' + date[0];
+        let newDate: Date = new Date(date);
+        return newDate.getTime();
+      }
+      
+  }
+  
+}

--- a/src/server/webapps/register-product/src/app/shared/services/Resources.ts
+++ b/src/server/webapps/register-product/src/app/shared/services/Resources.ts
@@ -183,7 +183,17 @@ export class ResourcesService {
   }
 
   public getOrdersByOutput (output: boolean): Observable<Interfaces.Order[]> {
-    return this.$http.get('http://localhost:8000/api/get/orders?output=' + output).map((res: Response) => res.json());
+    return this.$http.get('http://localhost:8000/api/get/orders/output/' + output).map((res: Response) => res.json());
+  }
+
+  public registerType (type: Interfaces.Type): Observable<Interfaces.Type> {
+    return this.$http.post('http://localhost:8000/api/add/type', {
+        name : type.name
+	  }).map((res: Response) => res.json());
+  }
+
+  public getOrdersByLate (late: boolean): Observable<Interfaces.Order[]> {
+    return this.$http.get('http://localhost:8000/api/get/orders/late/' + late).map((res: Response) => res.json());
   }
 
 }

--- a/src/server/webapps/register-product/src/app/shared/services/index.ts
+++ b/src/server/webapps/register-product/src/app/shared/services/index.ts
@@ -1,9 +1,11 @@
 import { DashboardService } from './Dashboard';
-import { ResourcesService } from './Resources'
+import { ResourcesService } from './Resources';
+import { DateService } from "./Date";
 
 export let sharedServices = {
   ResourcesService: ResourcesService,
-  DashboardService: DashboardService
+  DashboardService: DashboardService,
+  DateService: DateService
 };
 
 export let sharedServicesList = Object.keys(sharedServices).map((key) => {

--- a/src/server/webapps/show-order/src/app/components/ShowOrder/index.ts
+++ b/src/server/webapps/show-order/src/app/components/ShowOrder/index.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { UIRouter, Transition } from 'ui-router-ng2';
 import { ResourcesService } from "../../shared/services/Resources";
+import { DateService } from "../../shared/services/Date";
 
 @Component({
     selector: 'show-order',
@@ -14,6 +15,7 @@ export class ShowOrderComponent implements OnInit {
         billId: String;
         trans: Transition;
         resources: ResourcesService;
+        date: DateService;
         bill: any;
         order: any;
         remisionGuide: any;
@@ -21,9 +23,10 @@ export class ShowOrderComponent implements OnInit {
         products: any[];
 
     // Methods
-        constructor (trans: Transition, resources: ResourcesService) {
+        constructor (trans: Transition, resources: ResourcesService, date: DateService) {
             this.trans = trans;
             this.resources = resources;
+            this.date = date;
             this.billId = this.trans.params().billId;
             this.bill = {};
             this.order = {};
@@ -78,6 +81,10 @@ export class ShowOrderComponent implements OnInit {
                     console.log(err);
                 }
             )
+        }
+
+        setDate(date: number) {
+            return this.date.convertDate(date);
         }
 
         updateBulk () {

--- a/src/server/webapps/show-order/src/app/components/ShowOrder/template.pug
+++ b/src/server/webapps/show-order/src/app/components/ShowOrder/template.pug
@@ -3,7 +3,9 @@ div.container
     table.table.table-bordered
         tr
             th Date
-            td {{bill.timestamp}}
+            td(
+                *ngIf="bill.timestamp"
+            ) {{setDate(bill.timestamp)}}
         tr
             th Subtotal:
             td {{bill.subtotal}}

--- a/src/server/webapps/show-order/src/app/shared/services/Date.ts
+++ b/src/server/webapps/show-order/src/app/shared/services/Date.ts
@@ -4,15 +4,14 @@ import {Injectable} from '@angular/core';
 export class DateService {
 
   // Attributes
-    now: number;
     
   // Methods
   constructor () {
-    this.now = 0;
   }
 
   convertDate(date: any): any {
       if(typeof(date) == 'number') {
+          console.log(123);
         let newDate: Date = new Date(date);
         return newDate.getDate() + '-' + (newDate.getMonth() + 1) + '-' + newDate.getFullYear();
       }

--- a/src/server/webapps/show-order/src/app/shared/services/Date.ts
+++ b/src/server/webapps/show-order/src/app/shared/services/Date.ts
@@ -1,0 +1,29 @@
+import {Injectable} from '@angular/core';
+
+@Injectable()
+export class DateService {
+
+  // Attributes
+    now: number;
+    
+  // Methods
+  constructor () {
+    this.now = 0;
+  }
+
+  convertDate(date: any): any {
+      if(typeof(date) == 'number') {
+          console.log(123);
+        let newDate: Date = new Date(date);
+        return newDate.getDate() + '-' + (newDate.getMonth() + 1) + '-' + newDate.getFullYear();
+      }
+      else{
+        date = date.split('-');
+        date = date[1] + '/' + date[2] + '/' + date[0];
+        let newDate: Date = new Date(date);
+        return newDate.getTime();
+      }
+      
+  }
+  
+}

--- a/src/server/webapps/show-order/src/app/shared/services/Date.ts
+++ b/src/server/webapps/show-order/src/app/shared/services/Date.ts
@@ -13,7 +13,6 @@ export class DateService {
 
   convertDate(date: any): any {
       if(typeof(date) == 'number') {
-          console.log(123);
         let newDate: Date = new Date(date);
         return newDate.getDate() + '-' + (newDate.getMonth() + 1) + '-' + newDate.getFullYear();
       }

--- a/src/server/webapps/show-order/src/app/shared/services/index.ts
+++ b/src/server/webapps/show-order/src/app/shared/services/index.ts
@@ -1,9 +1,11 @@
 import { DashboardService } from './Dashboard';
-import { ResourcesService } from './Resources'
+import { ResourcesService } from './Resources';
+import { DateService } from "./Date";
 
 export let sharedServices = {
   ResourcesService: ResourcesService,
-  DashboardService: DashboardService
+  DashboardService: DashboardService,
+  DateService: DateService
 };
 
 export let sharedServicesList = Object.keys(sharedServices).map((key) => {


### PR DESCRIPTION
Se ha agregado un servicio que ayuda a la conversión de fechas del modelo convencional de un input (mm/dd/YYYY) a un número entero en milisegundos y viceversa.
Para usarlo hay que importar el servicio en el componente y hacer uso de tal con la función convertDate(fecha). Esta función retorna un número entero o un string dependeiendo de la necesidad.